### PR TITLE
Fix: Issue 259 - Modify condition of naming for last layer

### DIFF
--- a/ctlearn/tools/predict_model.py
+++ b/ctlearn/tools/predict_model.py
@@ -471,7 +471,7 @@ class PredictCTLearnModel(Tool):
         # Load the model from the specified path
         model = keras.saving.load_model(model_path)
         prediction_colname = (
-            model.layers[-1].name if model.layers[-1].name != "softmax" else "type"
+            "type" if isinstance(model.layers[-1], keras.layers.Softmax) else model.layers[-1].name
         )
         backbone_model, feature_vectors = None, None
         if self.dl1_features:


### PR DESCRIPTION
Solution to the prediction of classification model (particle type) error (#259). This occurs when using LoadedModel or SimpleCNN subclass of CTLearnModel. This is due to a naming behaviour where the last layer name was expecting to finish with "_softmax". With LoadedModel and SimpleCNN, the naming wasn't working as expected, so in order to be more flexible, the condition changed from looking at the last layer name to looking at the type of layer (softmax for classification task)